### PR TITLE
Remove ajshort/silverstripe-gridfieldextensions as it is abandoned,

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,6 @@
         "silverstripe/framework": "3.1.*",
         "silverstripe/cms": "3.1.*",
         "silverstripe/widgets": "0.2.0",
-        "ajshort/silverstripe-gridfieldextensions" : "1.0.*"
+        "silverstripe-australia/gridfieldextensions" : "1.0.*"
     }
 }


### PR DESCRIPTION
Package ajshort/silverstripe-gridfieldextensions is now abandoned, it is recommended to use silverstripe-australia/gridfieldextensions instead.
