### PR TITLE
Move WidgetArea creation to onBeforeWrite.

### DIFF
--- a/code/WidgetDataObject.php
+++ b/code/WidgetDataObject.php
@@ -46,8 +46,8 @@ class WidgetDataObject extends DataExtension {
 	/**
 	 * Creates WidgetArea DataObjects in not aleready done.
 	 */
-	public function onAfterWrite() {
-		parent::onAfterWrite();
+	public function onBeforeWrite() {
+		parent::onBeforeWrite();
 
 		$has_one = $this->owner->has_one();
 		// Loop over each WidgetArea
@@ -55,18 +55,9 @@ class WidgetDataObject extends DataExtension {
 			if ($class == 'WidgetArea') {
 				// Create the WidgetArea if it not exist
 				$dbName = $name . 'ID';
-				// Can't use $this->owner->$name()->ID since it doesn't
-				// work with DataObjects, it works just with Pages. SS bug?
-				if ($this->owner->$dbName == 0) {
-					$wa = new WidgetArea();
-					$wa->write();
-					$this->owner->$dbName = $wa->ID;
-					if ($this->owner->hasExtension('Versioned')) {
-						$this->owner->writeWithoutVersion();
-					} else {
-						$dbg = $this->owner->$name();
-						$this->owner->write();
-					}
+				$wa = $this->owner->$name();
+				if (!$wa->exists()){
+					$this->owner->$dbName = $wa->write();
 				}
 			}
 		}

--- a/code/WidgetPage.php
+++ b/code/WidgetPage.php
@@ -28,11 +28,11 @@ class WidgetPage extends WidgetDataObject {
 	/**
 	 * Creates WidgetArea DataObjects in not aleready done.
 	 */
-	public function onAfterWrite() {
+	public function onBeforeWrite() {
 
 		// Check if this page needs its own WidgetArea
 		if ($this->owner->InheritSideBar == false) {
-			parent::onAfterWrite();
+			parent::onBeforeWrite();
 		}
 	}
 	


### PR DESCRIPTION
I was having issues with UnsavedRationList and grid fields as well as Versioned throwing exceptions about duplicate keys.

Moving the logic to onBeforeWrite and removing the additional writeWithoutVersion/write has solved it.